### PR TITLE
90%: Remove spacing for MS transforms properties

### DIFF
--- a/css/external.css
+++ b/css/external.css
@@ -139,35 +139,35 @@
 
 
   .fa-rotate-90 {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=1);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
       -webkit-transform: rotate(90deg);
       -ms-transform: rotate(90deg);
       transform: rotate(90deg);
   }
 
   .fa-rotate-180 {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=2);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
       -webkit-transform: rotate(180deg);
       -ms-transform: rotate(180deg);
       transform: rotate(180deg);
   }
 
   .fa-rotate-270 {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=3);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       -webkit-transform: rotate(270deg);
       -ms-transform: rotate(270deg);
       transform: rotate(270deg);
   }
 
   .fa-flip-horizontal {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
       -webkit-transform: scale(-1, 1);
       -ms-transform: scale(-1, 1);
       transform: scale(-1, 1);
   }
 
   .fa-flip-vertical {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
       -webkit-transform: scale(1, -1);
       -ms-transform: scale(1, -1);
       transform: scale(1, -1);

--- a/css/ie-only.css
+++ b/css/ie-only.css
@@ -133,35 +133,35 @@
 
 
   .fa-rotate-90 {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=1);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
       -webkit-transform: rotate(90deg);
       -ms-transform: rotate(90deg);
       transform: rotate(90deg);
   }
 
   .fa-rotate-180 {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=2);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
       -webkit-transform: rotate(180deg);
       -ms-transform: rotate(180deg);
       transform: rotate(180deg);
   }
 
   .fa-rotate-270 {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=3);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       -webkit-transform: rotate(270deg);
       -ms-transform: rotate(270deg);
       transform: rotate(270deg);
   }
 
   .fa-flip-horizontal {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
       -webkit-transform: scale(-1, 1);
       -ms-transform: scale(-1, 1);
       transform: scale(-1, 1);
   }
 
   .fa-flip-vertical {
-      filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
+      filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
       -webkit-transform: scale(1, -1);
       -ms-transform: scale(1, -1);
       transform: scale(1, -1);


### PR DESCRIPTION
This fixes an issue whereby the Rails asset pipeline Sass compiler fails with the following error:
`Sass::SyntaxError: Invalid CSS after "... filter: progid": expected ";", was ": DXImageTransf..."`